### PR TITLE
fix(tests): corrige comparación de versiones en test_ml_smoke.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ testing = [
   "daphne",
   "factory-boy~=3.3.1",
   "imagehash",
+  "packaging",
   "pytest~=8.4.1",
   "pytest-cov~=7.0.0",
   "pytest-django~=4.11.1",

--- a/src/documents/tests/test_ml_smoke.py
+++ b/src/documents/tests/test_ml_smoke.py
@@ -12,6 +12,7 @@ Task: TSK-CICD-AUDIT-001
 """
 
 import pytest
+from packaging import version
 
 
 class TestMLDependenciesAvailable:
@@ -21,7 +22,7 @@ class TestMLDependenciesAvailable:
         """Verify PyTorch is installed and importable."""
         import torch
 
-        assert torch.__version__ >= "2.0.0", (
+        assert version.parse(torch.__version__) >= version.parse("2.0.0"), (
             f"PyTorch version {torch.__version__} is too old. "
             f"Minimum required: 2.0.0"
         )
@@ -30,7 +31,7 @@ class TestMLDependenciesAvailable:
         """Verify Transformers library is installed and importable."""
         import transformers
 
-        assert transformers.__version__ >= "4.30.0", (
+        assert version.parse(transformers.__version__) >= version.parse("4.30.0"), (
             f"Transformers version {transformers.__version__} is too old. "
             f"Minimum required: 4.30.0"
         )
@@ -39,7 +40,7 @@ class TestMLDependenciesAvailable:
         """Verify OpenCV is installed and importable."""
         import cv2
 
-        assert cv2.__version__ >= "4.8.0", (
+        assert version.parse(cv2.__version__) >= version.parse("4.8.0"), (
             f"OpenCV version {cv2.__version__} is too old. "
             f"Minimum required: 4.8.0"
         )
@@ -54,7 +55,7 @@ class TestMLDependenciesAvailable:
         """Verify scikit-learn is installed and importable."""
         import sklearn
 
-        assert sklearn.__version__ >= "1.7.0", (
+        assert version.parse(sklearn.__version__) >= version.parse("1.7.0"), (
             f"scikit-learn version {sklearn.__version__} is too old. "
             f"Minimum required: 1.7.0"
         )
@@ -63,7 +64,7 @@ class TestMLDependenciesAvailable:
         """Verify NumPy is installed and importable."""
         import numpy as np
 
-        assert np.__version__ >= "1.26.0", (
+        assert version.parse(np.__version__) >= version.parse("1.26.0"), (
             f"NumPy version {np.__version__} is too old. "
             f"Minimum required: 1.26.0"
         )
@@ -72,7 +73,7 @@ class TestMLDependenciesAvailable:
         """Verify Pandas is installed and importable."""
         import pandas as pd
 
-        assert pd.__version__ >= "2.0.0", (
+        assert version.parse(pd.__version__) >= version.parse("2.0.0"), (
             f"Pandas version {pd.__version__} is too old. "
             f"Minimum required: 2.0.0"
         )


### PR DESCRIPTION
Soluciona el error en test_opencv_available donde las versiones se comparaban como strings en vez de valores semánticos, causando que 4.11.0 fuera considerada menor que 4.8.0.

Cambios:
- Importa packaging.version para comparaciones correctas
- Modifica todas las comparaciones de versiones para usar version.parse()
- Añade packaging a las dependencias de testing en pyproject.toml

Esto asegura que versiones como 4.11.0 sean correctamente reconocidas como superiores a 4.8.0.

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the contributing guidelines.
- [ ] If applicable, I have included testing coverage for new code in this PR, for backend and / or front-end changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass.
- [ ] I have run all `pre-commit` hooks.
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
